### PR TITLE
Fix bad ordering of responses

### DIFF
--- a/lib/fastlane/plugin/latest_appcenter_build_number/actions/latest_appcenter_build_number_action.rb
+++ b/lib/fastlane/plugin/latest_appcenter_build_number/actions/latest_appcenter_build_number_action.rb
@@ -64,8 +64,8 @@ module Fastlane
           return nil
         end
 
-        releases.sort_by { |release| release['id'] }
-        latest_build = releases.first
+        sorted_release = releases.sort_by { |release| release['id'] }.reverse!
+        latest_build = sorted_release.first
 
         if latest_build.nil?
           UI.user_error!("The app has no versions yet")

--- a/lib/fastlane/plugin/latest_appcenter_build_number/version.rb
+++ b/lib/fastlane/plugin/latest_appcenter_build_number/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module LatestAppcenterBuildNumber
-    VERSION = "0.1.3"
+    VERSION = "1.0.0"
   end
 end

--- a/spec/fixtures/valid_release_response.json
+++ b/spec/fixtures/valid_release_response.json
@@ -1,18 +1,18 @@
 [
   {
     "origin": "hockeyapp",
-    "id": 5,
+    "id": 4,
     "short_version": "1.0.0",
     "version": "1.0.0.101",
-    "uploaded_at": "2019-09-05T17:42:55.000Z",
+    "uploaded_at": "2019-09-03T12:14:59.000Z",
     "enabled": true
   },
   {
     "origin": "hockeyapp",
-    "id": 4,
+    "id": 5,
     "short_version": "1.0.1",
     "version": "1.0.1.102",
-    "uploaded_at": "2019-09-03T12:14:59.000Z",
+    "uploaded_at": "2019-09-05T17:42:55.000Z",
     "enabled": true
   },
   {
@@ -46,7 +46,7 @@
   },
   {
     "origin": "appcenter",
-    "id": 1,
+    "id": 7,
     "short_version": "1.0.4",
     "version": "1.0.4.105",
     "uploaded_at": "2019-09-06T19:33:21.000Z",

--- a/spec/latest_appcenter_build_number_action_spec.rb
+++ b/spec/latest_appcenter_build_number_action_spec.rb
@@ -146,19 +146,7 @@ describe Fastlane::Actions::LatestAppcenterBuildNumberAction do
           app_name: 'App-Name'
         )
       end").runner.execute(:test)
-      expect(build_number).to eq('1.0.0.101')
-    end
-
-    it "raises an error if no owner name was given" do
-      stub_get_apps_success(200)
-      stub_get_releases_success(200)
-      build_number = Fastlane::FastFile.new.parse("lane :test do
-        latest_appcenter_build_number(
-          api_token: '1234',
-          app_name: 'App-Name'
-        )
-      end").runner.execute(:test)
-      expect(build_number).to eq('1.0.0.101')
+      expect(build_number).to eq('1.0.4.105')
     end
   end
 end


### PR DESCRIPTION
Hit an issue where the AppCenter API wasn't returning the `releases` response in order. I thought I was already sorting these by id anyway, but it turns out I wasn't... this PR fixes that oversight.

Also. this is being used well and widely so setting the version to 1.0.0 too 🎉 